### PR TITLE
Activating direnv on fish startup

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,4 +1,5 @@
 if type -q direnv
+  eval (direnv export fish)
   function __direnv_export_eval --on-variable PWD
     status --is-command-substitution; and return
     eval (direnv export fish)


### PR DESCRIPTION
This is a quick fix for issue https://github.com/oh-my-fish/plugin-direnv/issues/2 ; the fix for rvm https://github.com/oh-my-fish/plugin-direnv/commit/c86058d8cca8fd953fe0249d08f300e9f4916e31 limits the activation of direnv on directory change, which doesn't happen when the command line is booted (ie. when a new tab or split is open), even though the directory may be direnv-allowed.

This way, the rvm fix should still work (since I'm not using rvm, it would be best if someone using it could confirm ^^°) and new tabs / splits should be direnved right away.
